### PR TITLE
🚬🐔

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "malinajs-unplugin": "^0.0.9",
     "prettier": "^2.4.1",
     "typescript": "^4.4.4",
-    "vite": "^2.6.10",
+    "vite": "^2.6.13",
     "vite-plugin-html": "^2.1.1",
     "vite-plugin-singlefile": "^0.5.1"
   },
   "dependencies": {
-    "malinajs": "^0.6.46",
-    "storxy": "^0.1.5"
+    "malinajs": "^0.6.47",
+    "storxy": "^0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "school-slave-generator",
   "description": "Генератор карточек для школьного дежурства",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vite-plugin-singlefile": "^0.5.1"
   },
   "dependencies": {
-    "malinajs": "^0.6.47",
+    "malinajs": "^0.6.49",
     "storxy": "^0.1.6"
   }
 }

--- a/src/app/app.css.ts
+++ b/src/app/app.css.ts
@@ -13,7 +13,7 @@ export const aside = style({
   flexDirection: 'column',
   padding: '1rem 0',
   '@media': {
-    '(max-width: 512px)': {
+    '(max-width: 625px)': {
       width: '100%',
       position: 'relative',
       margin: 'auto',
@@ -37,16 +37,13 @@ export const main = style({
   gridTemplateColumns: `repeat(2, 1fr)`,
   gridRowGap: '1rem',
   rowGap: '1rem',
-  paddingTop: '2rem',
-  '::after': {
-    content: `''`,
-    height: '2rem',
-  },
+  padding: '2rem 0',
   '@media': {
     '(max-width: 1150px)': {
       gridTemplateColumns: '1fr',
     },
-    '(max-width: 512px)': {
+    '(max-width: 625px)': {
+      minHeight: '100vh',
       width: '100%',
       position: 'relative',
       margin: 'auto',

--- a/src/components/Modal.xht
+++ b/src/components/Modal.xht
@@ -38,7 +38,7 @@ const close = () => {
           class={styles.window}
           role="dialog"
           aria-modal="true"
-          *clickOutside={close}
+          {* $runtime.bindAction($cd, $element, clickOutside, () => [close])}
           #modalWindow
         >
           <header class={styles.header}>

--- a/src/components/card.css.ts
+++ b/src/components/card.css.ts
@@ -23,9 +23,6 @@ export const card = style({
       height: '26rem',
     },
   },
-  ':hover': {
-    boxShadow: `inset rgba(0, 0, 0, 0.096) 0 0 1px 2px`,
-  },
 })
 
 export const add = style({

--- a/src/components/modal.css.ts
+++ b/src/components/modal.css.ts
@@ -19,7 +19,7 @@ export const windowWrap = style({
   margin: '2rem',
   maxHeight: '100%',
   '@media': {
-    '(max-width: 512px)': {
+    '(max-width: 625px)': {
       margin: '2rem auto',
     },
   },

--- a/src/styles/select.css.ts
+++ b/src/styles/select.css.ts
@@ -32,15 +32,6 @@ export const select = style({
     '(-webkit-appearance: none)': {
       WebkitAppearance: 'none',
       appearance: 'none',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: `right .2rem top 50%, 0 0`,
-      backgroundSize: `2rem auto, 100%`,
-      backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1' d='M15.25 10.75L12 14.25L8.75 10.75'%3E%3C/path%3E%3C/svg%3E%0A")`,
-      '@media': {
-        '(prefers-color-scheme: dark)': {
-          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='%23eee' stroke-linecap='round' stroke-linejoin='round' stroke-width='1' d='M15.25 10.75L12 14.25L8.75 10.75'%3E%3C/path%3E%3C/svg%3E%0A")`,
-        },
-      },
     },
   },
 })
@@ -48,4 +39,19 @@ export const select = style({
 export const label = style({
   width: '70%',
   marginBottom: '.5625rem',
+  position: 'relative',
+  '::after': {
+    content: '',
+    position: 'absolute',
+    top: '1.85rem',
+    right: '.5rem',
+    width: '2rem',
+    height: '2rem',
+    pointerEvents: 'none',
+    backgroundColor: 'currentColor',
+    WebkitMask: `${vars.icons.arrow_down} no-repeat`,
+    WebkitMaskSize: '2rem 2rem',
+    mask: `${vars.icons.arrow_down} no-repeat`,
+    maskSize: '2rem 2rem',
+  },
 })

--- a/src/styles/select.css.ts
+++ b/src/styles/select.css.ts
@@ -43,10 +43,10 @@ export const label = style({
   '::after': {
     content: '',
     position: 'absolute',
-    top: '1.85rem',
+    top: 'calc(100% - 2.2812rem)',
+    bottom: 0,
     right: '.5rem',
     width: '2rem',
-    height: '2rem',
     pointerEvents: 'none',
     backgroundColor: 'currentColor',
     WebkitMask: `${vars.icons.arrow_down} no-repeat`,

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -7,8 +7,6 @@ export const vars = createGlobalTheme(':root', {
       50: '#f9fafb',
       100: '#f3f4f6',
       200: '#e5e7eb',
-      300: '#d1d5db',
-      400: '#9ca3af',
       500: '#6b7280',
       600: '#4b5563',
       700: '#374151',
@@ -18,6 +16,9 @@ export const vars = createGlobalTheme(':root', {
   },
   font: {
     sans: `ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"`,
+  },
+  icons: {
+    arrow_down: `url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1' d='M15.25 10.75L12 14.25L8.75 10.75'%3E%3C/path%3E%3C/svg%3E")`,
   },
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,6 @@ export default defineConfig(({ mode }) => {
     plugins: [
       malinaPlugin({
         debugLabel: DEV,
-        hideLabel: !DEV,
         immutable: true,
       }),
       vanillaExtractPlugin(),
@@ -19,11 +18,10 @@ export default defineConfig(({ mode }) => {
       !DEV && minifyHtml(),
     ],
     build: {
-      target: ['chrome64'],
-      polyfillDynamicImport: false,
+      target: ['es2018'],
+      polyfillModulePreload: false,
       cssCodeSplit: false,
       rollupOptions: {
-        inlineDynamicImports: true,
         output: {
           manualChunks: () => 'everything.js',
         },


### PR DESCRIPTION
- Removed `box-shadow` on card's hover
- Changed build target: now it is `es2018`. That means website wil works on:
    - Safari 13.1.3 (15609.4.1)
    - Chromium 64.0.3275.0
    - Firefox 78.15.0esr
- Select icon now uses `::after` in pair with [`mask`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask) instead of `background-image`